### PR TITLE
Also fix NetBSD build

### DIFF
--- a/ptyproxy.c
+++ b/ptyproxy.c
@@ -16,7 +16,7 @@
 #include <pty.h>
 #elif defined(__FreeBSD__)
 #include <libutil.h>
-#elif defined(__APPLE__) || defined(__OpenBSD__)
+#elif defined(__APPLE__) || defined(__OpenBSD__) || defined(__NetBSD__)
 #include <util.h>
 #include <sys/ioctl.h>
 #endif


### PR DESCRIPTION
I had expected `BSD` to be defined so the check could be simplified but it isn't. Not sure why.